### PR TITLE
Update CI branch from master to trunk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,4 +63,4 @@ workflows:
             - tests
           filters:
             branches:
-              only: master
+              only: trunk


### PR DESCRIPTION
We have renamed the default branch from `master` to `trunk`. This PR updates the CI config file to reflect that change.