### PR TITLE
Add notice about the repository deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## [DEPRECATED] _This repository is no longer used, as in Gutenberg we now use the original version of this package, plus fetching [a prebuilt Android artifact from a maven repo on S3](https://github.com/wordpress-mobile/react-native-libraries-publisher/blob/trunk/README.md)._
+
 # React Native WebView - a Modern, Cross-Platform WebView for React Native
 
 [![star this repo](http://githubbadges.com/star.svg?user=react-native-webview&repo=react-native-webview&style=flat)](https://github.com/react-native-webview/react-native-webview)


### PR DESCRIPTION
This package is no longer used in Gutenberg as we now use the original repository ([reference](https://github.com/WordPress/gutenberg/blob/b067d3131b0e0b42018aad1bcee87c0d19abed23/packages/react-native-editor/package.json#L76)). For this reason, I added a notice about the deprecation, and ideally we should archive it.

From the [GitHub documentation about archiving](https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories), everything on the repo will be read-only but not deleted. So, if in the future we need to restore it, we could easily do it by unarchiving it.

@hypest Since I don't have permission to archive the repository, I'd appreciate it if you could help me with that, thanks 🙇 .